### PR TITLE
Fix current time on new record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+#Ignore ruby-gemset file
+.ruby-gemset
+
 # Ignore all logfiles and tempfiles.
 /log/*
 !/log/.keep

--- a/app/models/time_record.rb
+++ b/app/models/time_record.rb
@@ -1,7 +1,7 @@
 class TimeRecord
   include Mongoid::Document
 
-  field :time, type: Time, default: Time.current
+  field :time, type: Time, default: -> { Time.current }
 
   embedded_in :day_record
 


### PR DESCRIPTION
Fix #73 . Changed the default time of a record to use a Proc to always evaluate the current time.