### PR TITLE
Bugfix dashboard nil

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,9 @@
 class RegistrationsController < Devise::RegistrationsController
+  include BeforeRender
+
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  before_action :set_dashboard, only: [:edit]
+  before_render :set_dashboard, except: [:new, :create]
 
   def update
     @user = User.find(current_user.id)

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -10,6 +10,7 @@ describe RegistrationsController do
     before { get :new }
 
     it { is_expected.to render_template(:new) }
+    it { expect(assigns(:dashboard)).to be_nil }
     it { expect(assigns(:user)).to be_instance_of(User) }
   end
 
@@ -81,6 +82,7 @@ describe RegistrationsController do
 
         it { is_expected.to render_template :edit }
         it { expect(assigns(:user).errors).not_to be_empty }
+        it { expect(assigns(:dashboard)).not_to be_nil }
       end
 
     end


### PR DESCRIPTION
Fixes #102 

Corrige comportamento quando usuário informa algo inválido na edição de usuário e o dashboard não é setado.