### PR TITLE
Allowance time

### DIFF
--- a/app/controllers/concerns/before_render.rb
+++ b/app/controllers/concerns/before_render.rb
@@ -8,7 +8,7 @@ module BeforeRender
 
   def render_with_before_render_action(*options, &block)
     run_callbacks :render do
-      render_without_before_render_action *options, &block
+      render_without_before_render_action(*options, &block)
     end
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -57,7 +57,7 @@ class RegistrationsController < Devise::RegistrationsController
         :password,
         :password_confirmation,
         :current_password,
-        accounts_attributes: [:id, :name, :workload, :lunch_time, :warn_straight_hours, :warn_overtime, :warn_rest_period, :hourly_rate, :_type, :_destroy])
+        accounts_attributes: [:id, :name, :workload, :lunch_time, :warn_straight_hours, :warn_overtime, :warn_rest_period, :hourly_rate, :allowance_time, :_type, :_destroy])
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,8 +35,9 @@ module ApplicationHelper
     flashes[type]['icon']
   end
 
-  def display_labor_laws_violations(violations)
-    (render 'day_records/labor_law_violation', violations: violations).html_safe
+  def display_labor_laws_violations(day, account)
+    return unless account.class == CltWorkerAccount
+    (render 'day_records/labor_law_violation', violations: day.labor_laws_violations).html_safe
   end
 
   private

--- a/app/models/clt_worker_account.rb
+++ b/app/models/clt_worker_account.rb
@@ -7,4 +7,6 @@ class CltWorkerAccount < Account
   field :warn_overtime, type: Boolean, default: true
   field :warn_rest_period, type: Boolean, default: true
 
+  field :allowance_time, type: Time
+
 end

--- a/app/models/concerns/day_record/account_manipulable.rb
+++ b/app/models/concerns/day_record/account_manipulable.rb
@@ -1,0 +1,17 @@
+module DayRecord::AccountManipulable
+  include DayRecord::CltWorkerAccountManipulable
+  extend ActiveSupport::Concern
+  
+  included do
+    
+  end
+
+  def account_manipulate_balance
+    clt_manipulate_balance if account.class == CltWorkerAccount
+  end
+
+  def account_manipulate_over_diff(diff, worked_hours, index)
+    clt_manipulate_over_diff(diff, worked_hours, index) if account.class == CltWorkerAccount
+  end
+
+end

--- a/app/models/concerns/day_record/clt_worker_account_manipulable.rb
+++ b/app/models/concerns/day_record/clt_worker_account_manipulable.rb
@@ -1,8 +1,6 @@
 module DayRecord::CltWorkerAccountManipulable
   extend ActiveSupport::Concern
   
-  ZERO_HOUR = Time.zone.local(1999, 8, 1).change(hour: 0, minute: 0)
-  
   included do
     
   end
@@ -25,7 +23,7 @@ module DayRecord::CltWorkerAccountManipulable
   end
 
   def forecast_departure_time
-    return ZERO_HOUR if time_records.empty? || !reference_date.today?
+    return DayRecord::ZERO_HOUR if time_records.empty? || !reference_date.today?
     rest = calculate_hours(false)
 
     add_lunch_time(sum_times(time_records.first.time, account.workload, rest))
@@ -43,13 +41,11 @@ module DayRecord::CltWorkerAccountManipulable
   end
 
   def check_straight_hours_violation(diff)
-    return false unless account.class == CltWorkerAccount
     return false unless account.warn_straight_hours
     @straight_hours_violation = @straight_hours_violation || (diff[:hour].hours + diff[:minute].minutes) > 6.hours
   end
 
   def check_overtime_violation
-    return false unless account.class == CltWorkerAccount
     return false unless account.warn_overtime
     (total_worked.hour.hours + total_worked.min.minutes) > (account.workload.hour.hours + account.workload.min.minutes + 2.hours)
   end

--- a/app/models/concerns/day_record/clt_worker_account_manipulable.rb
+++ b/app/models/concerns/day_record/clt_worker_account_manipulable.rb
@@ -1,0 +1,57 @@
+module DayRecord::CltWorkerAccountManipulable
+  extend ActiveSupport::Concern
+  
+  ZERO_HOUR = Time.zone.local(1999, 8, 1).change(hour: 0, minute: 0)
+  
+  included do
+    
+  end
+
+  def clt_manipulate_balance
+    return unless account.allowance_time  
+    allowance = (account.allowance_time.hour.hours + account.allowance_time.min.minutes)
+    @balance.reset if @balance.to_seconds <= allowance
+  end
+
+  def clt_manipulate_over_diff(diff, worked_hours, index)
+    check_straight_hours_violation(diff) if worked_hours && index.odd?
+  end
+
+  def add_lunch_time(time)
+    return time unless account.lunch_time
+    return time unless time_records.size < 3
+
+    sum_times(time, account.lunch_time)
+  end
+
+  def forecast_departure_time
+    return ZERO_HOUR if time_records.empty? || !reference_date.today?
+    rest = calculate_hours(false)
+
+    add_lunch_time(sum_times(time_records.first.time, account.workload, rest))
+  end
+
+  def labor_laws_violations
+    @violations ||= check_labor_laws_violations
+  end
+
+  def check_labor_laws_violations
+    {
+      overtime: check_overtime_violation,
+      straight_hours: @straight_hours_violation
+    }
+  end
+
+  def check_straight_hours_violation(diff)
+    return false unless account.class == CltWorkerAccount
+    return false unless account.warn_straight_hours
+    @straight_hours_violation = @straight_hours_violation || (diff[:hour].hours + diff[:minute].minutes) > 6.hours
+  end
+
+  def check_overtime_violation
+    return false unless account.class == CltWorkerAccount
+    return false unless account.warn_overtime
+    (total_worked.hour.hours + total_worked.min.minutes) > (account.workload.hour.hours + account.workload.min.minutes + 2.hours)
+  end
+
+end

--- a/app/models/concerns/day_record/clt_worker_account_manipulable.rb
+++ b/app/models/concerns/day_record/clt_worker_account_manipulable.rb
@@ -47,7 +47,15 @@ module DayRecord::CltWorkerAccountManipulable
 
   def check_overtime_violation
     return false unless account.warn_overtime
-    (total_worked.hour.hours + total_worked.min.minutes) > (account.workload.hour.hours + account.workload.min.minutes + 2.hours)
+     total_worked_duration > overtime_limit
+  end
+
+  def total_worked_duration
+    (total_worked.hour.hours + total_worked.min.minutes)
+  end
+
+  def overtime_duration_limit
+    (account.workload.hour.hours + account.workload.min.minutes + 2.hours)
   end
 
 end

--- a/app/models/concerns/day_record/clt_worker_account_manipulable.rb
+++ b/app/models/concerns/day_record/clt_worker_account_manipulable.rb
@@ -47,7 +47,7 @@ module DayRecord::CltWorkerAccountManipulable
 
   def check_overtime_violation
     return false unless account.warn_overtime
-     total_worked_duration > overtime_limit
+     total_worked_duration > overtime_duration_limit
   end
 
   def total_worked_duration

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,17 +1,17 @@
 class Contact < MailForm::Base
-  attribute :name,      :validate => true
-  attribute :email,     :validate => /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
+  attribute :name,      validate: true
+  attribute :email,     validate: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
 
   attribute :message
-  attribute :nickname,  :captcha  => true
+  attribute :nickname,  captcha: true
 
   # Declare the e-mail headers. It accepts anything the mail method
   # in ActionMailer accepts.
   def headers
     {
-      :subject => "Contato do Site",
-      :to => "contato@meucontroledeponto.com.br",
-      :from => %("#{name}" <#{email}>)
+      subject: "Contato do Site",
+      to: "contato@meucontroledeponto.com.br",
+      from: %("#{name}" <#{email}>)
     }
   end
 end

--- a/app/models/day_record.rb
+++ b/app/models/day_record.rb
@@ -3,6 +3,8 @@ class DayRecord
   include DayRecord::AccountManipulable
   extend Enumerize
 
+  ZERO_HOUR = Time.zone.local(1999, 8, 1).change(hour: 0, minute: 0)
+
   field :reference_date, type: Date, default: -> { Date.current }
   field :observations, type: String
   field :work_day

--- a/app/models/day_record.rb
+++ b/app/models/day_record.rb
@@ -1,8 +1,7 @@
 class DayRecord
   include Mongoid::Document
+  include DayRecord::AccountManipulable
   extend Enumerize
-
-  ZERO_HOUR = Time.zone.local(1999, 8, 1).change(hour: 0, minute: 0)
 
   field :reference_date, type: Date, default: -> { Date.current }
   field :observations, type: String
@@ -40,38 +39,15 @@ class DayRecord
 
     work_day.yes? ? balance_for_working_day : balance_for_non_working_day
 
+    account_manipulate_balance
+
     @balance
-  end
-
-  def forecast_departure_time
-    return ZERO_HOUR if time_records.empty? || !reference_date.today?
-    rest = calculate_hours(false)
-
-    add_lunch_time(sum_times(time_records.first.time, account.workload, rest))
-  end
-
-  def labor_laws_violations
-    @violations ||= check_labor_laws_violations
   end
 
   private
 
-  def check_labor_laws_violations
-    {
-      overtime: check_overtime_violation,
-      straight_hours: @straight_hours_violation
-    }
-  end
-
   def sum_times(*times)
     times.inject { |sum, time| sum + time.hour.hours + time.min.minutes }
-  end
-
-  def add_lunch_time(time)
-    return time unless account.lunch_time
-    return time unless time_records.size < 3
-
-    sum_times(time, account.lunch_time)
   end
 
   def balance_for_working_day
@@ -104,7 +80,7 @@ class DayRecord
     time_records.each_with_index do |time_record, index|
       diff = Time.diff(reference_time.time, time_record.time)
       total = total + diff[:hour].hours + diff[:minute].minutes if satisfy_conditions(worked_hours, index)
-      check_straight_hours_violation(diff) if worked_hours && index.odd?
+      account_manipulate_over_diff(diff, worked_hours, index)
       reference_time = time_record
     end
 
@@ -122,18 +98,6 @@ class DayRecord
 
     now_diff = Time.diff(last_time_record, Time.current)
     (total + now_diff[:hour].hours) + now_diff[:minute].minutes
-  end
-
-  def check_straight_hours_violation(diff)
-    return false unless account.class == CltWorkerAccount
-    return false unless account.warn_straight_hours
-    @straight_hours_violation = @straight_hours_violation || (diff[:hour].hours + diff[:minute].minutes) > 6.hours
-  end
-
-  def check_overtime_violation
-    return false unless account.class == CltWorkerAccount
-    return false unless account.warn_overtime
-    (total_worked.hour.hours + total_worked.min.minutes) > (account.workload.hour.hours + account.workload.min.minutes + 2.hours)
   end
 
   def future_reference_date

--- a/app/models/time_balance.rb
+++ b/app/models/time_balance.rb
@@ -3,14 +3,11 @@ class TimeBalance
   attr_accessor :hour, :minute
 
   def initialize
-    self.hour = 0
-    self.minute = 0
+    reset
   end
 
   def calculate_balance(time_1, time_2)
     calculate(-(time_1.hour.hours + time_1.min.minutes), (time_2.hour.hours + time_2.min.minutes))
-
-    @cleared = time_1 == time_2
   end
 
   def positive?
@@ -33,6 +30,15 @@ class TimeBalance
 
   def to_s
     '%02d:%02d' % [self.hour.abs, self.minute.abs]
+  end
+
+  def to_seconds
+    (self.hour.abs.hours + self.minute.abs.minutes)
+  end
+
+  def reset
+    self.hour = 0
+    self.minute = 0
   end
 
   private

--- a/app/views/day_records/index.html.erb
+++ b/app/views/day_records/index.html.erb
@@ -27,9 +27,7 @@
         <tr title="<%= day_record.observations %>">
           <td>
             <h5 class="text-left"><%= l day_record.reference_date, format: :short %>
-              <% if current_user.current_account.class == CltWorkerAccount %>
-                <%= display_labor_laws_violations(day_record.labor_laws_violations) %>
-              <% end %>
+              <%= display_labor_laws_violations(day_record, current_user.current_account) %>
             </h5>
           </td>
           <% @max_time_records.times do |index| %>

--- a/app/views/devise/registrations/_account_fields.html.erb
+++ b/app/views/devise/registrations/_account_fields.html.erb
@@ -90,6 +90,22 @@
       </div>
     </div>
   </div>
+
+  <div class="form-group">
+    <label class="col-sm-3 control-label no-padding-right" for="form-field-date">Tempo de Abono</label>
+
+    <div class="col-sm-9">
+      <div class="input-medium">
+        <div class="input-group">
+          <%= f.input_field :allowance_time, class: 'timepicker', value: f.object.allowance_time.try(:strftime, "%H:%M") || Time.current.midnight.strftime("%H:%M") %>
+          <span class="input-group-addon">
+            <i class="ace-icon fa fa-clock-o"></i>
+          </span>
+          <%= f.full_error :allowance_time, class: 'text-danger' %>
+        </div>
+      </div>
+    </div>
+  </div>
   <% end %>
   <%= f.input :_type, as: :hidden, value: f.object.class %>
 </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -121,18 +121,26 @@ describe ApplicationHelper do
   end
 
   describe '.display_labor_laws_violations' do
+    let!(:user) { create(:user) }
+    let!(:account) { create(:account, user: user) }
+    let!(:day) { create(:day_record, account: account) }
+
     context 'overtime violation' do
       let(:violations) { {overtime: true, straight_hours: false} }
       let(:expected) { '<a class="balance-info" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-content="Você ultrapassou o limite de 2 horas extras diárias." title="Art. 49 CLT">  <i class="ace-icon fa fa-exclamation-triangle orange bigger-120"></i></a>' }
 
-      it { expect(display_labor_laws_violations(violations).to_str.tr("\r\n", "")).to eq expected }
+      before { allow(day).to receive(:labor_laws_violations).and_return(violations) }
+
+      it { expect(display_labor_laws_violations(day, account).to_str.tr("\r\n", "")).to eq expected }
     end
 
-    context 'overtime violation' do
+    context 'straight_hours violation' do
       let(:violations) { {overtime: false, straight_hours: true} }
       let(:expected) { '<a class="balance-info" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" data-content="Você trabalhou mais que 6 horas consecutivas sem um período de descanso." title="Art. 71 CLT">  <i class="ace-icon fa fa-exclamation-triangle orange bigger-120"></i></a>' }
 
-      it { expect(display_labor_laws_violations(violations).to_str.tr("\r\n", "")).to eq expected }
+      before { allow(day).to receive(:labor_laws_violations).and_return(violations) }
+
+      it { expect(display_labor_laws_violations(day, account).to_str.tr("\r\n", "")).to eq expected }
     end
 
   end


### PR DESCRIPTION
Permite uma conta CLT configurar um tempo de abono.

Se o usuário estiver dentro dos limites do abono, será considerado saldo zerado. Passando 1 minuto, ele terá o saldo calculado normalmente.

Ex: 10 min de abono.

9 minutos após expediente -> saldo 00:00
11 minutos após expediente -> saldo - 00:11

Closes #113