### PR TITLE
Atestado médico

### DIFF
--- a/app/controllers/day_records_controller.rb
+++ b/app/controllers/day_records_controller.rb
@@ -82,7 +82,7 @@ class DayRecordsController < GenericCrudController
   def model_params
     params.require(:day_record).
     permit(
-      :reference_date, :observations, :work_day, :missed_day,
+      :reference_date, :observations, :work_day, :missed_day, :medical_certificate,
       time_records_attributes: [:id, :time, :_destroy]
       )
   end

--- a/app/models/concerns/clt_worker_account_manipulable.rb
+++ b/app/models/concerns/clt_worker_account_manipulable.rb
@@ -2,9 +2,13 @@ module CltWorkerAccountManipulable
   extend ActiveSupport::Concern
 
   def clt_manipulate_balance(balance, allowance_time)
-    return unless allowance_time
-    allowance_period = (allowance_time.hour.hours + allowance_time.min.minutes)
-    balance.reset if balance.to_seconds <= allowance_period
+
+    if allowance_time
+      allowance_period = (allowance_time.hour.hours + allowance_time.min.minutes)
+      balance.reset if balance.to_seconds <= allowance_period
+    end
+
+    balance.reset if medical_certificate.yes?
   end
 
   def clt_manipulate_over_diff(diff, worked_hours, index)

--- a/app/models/day_record.rb
+++ b/app/models/day_record.rb
@@ -7,9 +7,11 @@ class DayRecord
   field :observations, type: String
   field :work_day
   field :missed_day
+  field :medical_certificate
 
   enumerize :work_day, in: { yes: 1, no: 0 }, default: :yes
   enumerize :missed_day, in: { yes: 1, no: 0 }, default: :no
+  enumerize :medical_certificate, in: { yes: 1, no: 0 }, default: :no
 
   belongs_to :account
   embeds_many :time_records
@@ -62,7 +64,7 @@ class DayRecord
     if missed_day.no?
       @balance.calculate_balance(ZERO_HOUR, total_worked)
     else
-      @balance.calculate_balance(ZERO_HOUR, ZERO_HOUR)
+      @balance.reset
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User
   end
 
   def check_current_account
-    return if current_account
+    return if accounts.active.first
     accounts.first.update_attribute(:active, true)
   end
 

--- a/app/views/day_records/_form.html.erb
+++ b/app/views/day_records/_form.html.erb
@@ -1,14 +1,19 @@
 <%= simple_form_for day_record do |f| %>
 <div class="row">
     <%= f.hidden_field :id %>
-    <%= f.input :reference_date, wrapper_html: {class: 'col-xs-4 col-sm-2 col-md-2 text-center'}, input_html: { value: (localize(f.object.reference_date) if f.object.reference_date), class: 'datepicker text-center'} %>
-    <%= f.input :work_day, wrapper_html: {class: 'col-xs-4 col-sm-2 col-md-2 text-center'}, label_html: {class: 'col-xs-12'} do %>
+    <%= f.input :reference_date, wrapper_html: {class: 'col-xs-3 col-md-2 text-center'}, input_html: { value: (localize(f.object.reference_date) if f.object.reference_date), class: 'datepicker text-center'} %>
+    <%= f.input :work_day, wrapper_html: {class: 'col-xs-3 col-md-2 text-center'}, label_html: {class: 'col-xs-12'} do %>
       <%= f.input_field :work_day, as: :boolean, class: 'yes-no-checkbox-switch', checked: f.object.work_day == 1  %>
     <% end %>
-    <%= f.input :missed_day, wrapper_html: {class: 'col-xs-4 col-sm-2 col-md-2 text-center'}, label_html: {class: 'col-xs-12'} do %>
+    <%= f.input :missed_day, wrapper_html: {class: 'col-xs-3 col-md-2 text-center'}, label_html: {class: 'col-xs-12'} do %>
       <%= f.input_field :missed_day, as: :boolean, class: 'yes-no-checkbox-switch', checked: f.object.missed_day == 1 %>
     <% end %>
-    <%= f.input :observations, as: :text, wrapper_html: {class: 'col-xs-12 col-sm-6 col-md-6'} %>
+    <% if current_user.current_account.class == CltWorkerAccount %>
+      <%= f.input :medical_certificate, wrapper_html: {class: 'col-xs-3 col-md-2 text-center'}, label_html: {class: 'col-xs-12'} do %>
+        <%= f.input_field :medical_certificate, as: :boolean, class: 'yes-no-checkbox-switch', checked: f.object.medical_certificate == 1 %>
+      <% end %>
+    <% end %>
+    <%= f.input :observations, as: :text, wrapper_html: {class: 'col-xs-12 col-md-4'} %>
 
 </div>
 <div class="row">

--- a/app/views/shared/_favicons.html.erb
+++ b/app/views/shared/_favicons.html.erb
@@ -1,5 +1,5 @@
-<%= favicon_link_tag "favicon.ico", rel: "shortcut icon", sizes: "16x16 32x32 48x48 64x64", type: nil %>
-<%= favicon_link_tag "favicon.ico", rel: "shortcut icon", type: "image/x-icon" %>
+<%= favicon_link_tag image_path("favicon.ico"), rel: "shortcut icon", sizes: "16x16 32x32 48x48 64x64", type: nil %>
+<%= favicon_link_tag image_path("favicon.ico"), rel: "shortcut icon", type: "image/x-icon" %>
 
 <%= favicon_link_tag "apple-icon-57x57.png", rel: "apple-touch-icon", sizes: "57x57", type: nil %>
 <%= favicon_link_tag "apple-icon-60x60.png", rel: "apple-touch-icon", sizes: "60x60", type: nil %>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -232,6 +232,7 @@ pt-BR:
         reference_date: Data
         work_day: Dia Útil?
         missed_day: Faltou?
+        medical_certificate: Atestado?
         observations: Observações
       time_record:
         time: Horário

--- a/spec/factories/day_record.rb
+++ b/spec/factories/day_record.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     reference_date Date.current
     work_day :yes
     missed_day :no
+    medical_certificate :no
     observations 'observations test'
 
     factory :day_record_with_times do


### PR DESCRIPTION
Closes #123 .

Nova opção para marcar o dia com atestado, dessa forma desconsidera o saldo, já que a empresa irá abonar as horas.