### PR TITLE
Validação de formato Big Decimal para hourly_rate em Self Employed Account

### DIFF
--- a/app/assets/javascripts/edit_user.js
+++ b/app/assets/javascripts/edit_user.js
@@ -1,8 +1,8 @@
 $(function(){
 
-  $('.input-money').maskMoney().maskMoney({thousands: '.', decimal: ','});
+  $('.input-money').maskMoney({thousands: '.', decimal: ','});
 
-  var errorField = $('.input-group > .text-danger:first'); 
+  var errorField = $('.input-group > .text-danger:first');
 
   if (errorField.length > 0) {
     errorField.parents('.tab-pane').each(function(index, value) {
@@ -29,6 +29,7 @@ $(function(){
   .on('cocoon:after-insert', function(e, insertedItem) {
     $(insertedItem).find('.timepicker').timepicker({showMeridian: false, minuteStep: 1});
     $(insertedItem).find('.yes-no-checkbox-switch').bootstrapSwitch({onText: 'Sim', offText: 'Não', onColor: 'success', offColor: 'danger'});
+    $(insertedItem).find('.input-money').maskMoney({thousands: '.', decimal: ','});
 
     var removesLeft = $('.remove_fields').not(':visible');
     removesLeft.show();
@@ -36,7 +37,7 @@ $(function(){
   .on("cocoon:after-remove", function(e, account) {
     var currentTab = $('.account-tabs li.active');
     var prevTab = currentTab.siblings().not('.dropdown').find('a');
-    
+
     currentTab.hide();
     prevTab.tab('show');
 

--- a/app/models/self_employed_account.rb
+++ b/app/models/self_employed_account.rb
@@ -1,5 +1,5 @@
 class SelfEmployedAccount < Account
-
   field :hourly_rate, type: BigDecimal, default: 0.0
 
+  validates_format_of :hourly_rate, with: /\A\d+(?:\.\d{0,2})?\z/
 end

--- a/app/presenters/account_presenter.rb
+++ b/app/presenters/account_presenter.rb
@@ -31,7 +31,7 @@ class AccountPresenter < Burgundy::Item
   end
 
   def total_earned
-    return 0 unless hourly_rate > 0
+    return 0 unless hourly_rate.to_i > 0
     @total_earned ||= calculate_earns
   end
 

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -241,6 +241,8 @@ pt-BR:
         end_date: Data Final
       account:
         name: Nome
+        hourly_rate: Valor/Hora
+
   enumerize:
     defaults:
       gender:

--- a/spec/controllers/closures_controller_spec.rb
+++ b/spec/controllers/closures_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ClosuresController do
 
-  let!(:user) { create(:user) }
+  let!(:user) { create(:user_sequence) }
   let!(:account) { user.current_account }
 
   describe '#index' do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -104,7 +104,7 @@ describe RegistrationsController do
     end
 
     context 'update SelfEmployedAcccount' do
-      let!(:account_atts) { { '0' => attributes_for(:account), '1' => attributes_for(:account_self_employed, hourly_rate: 50) } }
+      let!(:account_atts) { { '0' => attributes_for(:account), '1' => attributes_for(:self_employed_account, hourly_rate: 50) } }
 
       before do
         put :update, user: {

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -10,13 +10,13 @@ FactoryGirl.define do
 
   end
 
-  factory :account_self_employed, class: SelfEmployedAccount do
+  factory :self_employed_account, class: SelfEmployedAccount do
     _type 'SelfEmployedAccount'
     name 'Freelance for Company X'
     active true
     hourly_rate 30
 
-    factory :account_self_employed_sequence do
+    factory :self_employed_account_sequence do
       sequence(:name) { |n| "Account Self Employed #{n}" }
     end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Account, type: :model do
 
-  it { expect(build(:account)).to be_valid }
-
   context 'associations' do
     it { expect(subject).to belong_to :user }
     it { expect(subject).to have_many :day_records }

--- a/spec/models/closure_spec.rb
+++ b/spec/models/closure_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Closure do
 
-  it { expect(build(:closure)).to be_valid }
-
   context 'associations' do
     it { is_expected.to belong_to :account }
   end

--- a/spec/models/day_record_spec.rb
+++ b/spec/models/day_record_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe DayRecord do
 
-  it { expect(build(:day_record)).to be_valid }
-
   context 'associations' do
     it { is_expected.to belong_to :account }
     it { is_expected.to embed_many :time_records }

--- a/spec/models/self_employed_account_spec.rb
+++ b/spec/models/self_employed_account_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe SelfEmployedAccount, type: :model do
+  context 'validations' do
+    it { is_expected.to allow_value(9.99, 0.0).for(:hourly_rate) }
+    it { is_expected.not_to allow_value('', nil).for(:hourly_rate) }
+  end
+end

--- a/spec/models/time_record_spec.rb
+++ b/spec/models/time_record_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe TimeRecord do
 
-  it { expect(build(:time_record)).to be_valid }
-
   context 'validations' do
     it { is_expected.to validate_presence_of :time }
     it { is_expected.to be_embedded_in :day_record }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe User do
 
-  it { expect(build(:user)).to be_valid }
-
   context 'associations' do
     it { is_expected.to have_many :accounts }
   end

--- a/spec/presenters/account_presenter_spec.rb
+++ b/spec/presenters/account_presenter_spec.rb
@@ -54,7 +54,7 @@ describe AccountPresenter do
   end
 
   describe '#total_earned' do
-    let!(:self_emp_account) { create(:account_self_employed_sequence, hourly_rate: 0) }
+    let!(:self_emp_account) { create(:self_employed_account_sequence, hourly_rate: 0) }
     let!(:day) { create(:day_record, account: self_emp_account) }
     let!(:presenter) { AccountPresenter.new(self_emp_account) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,4 +10,5 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Mongoid::Matchers, type: :model
   config.infer_spec_type_from_file_location!
+  FactoryGirl.lint
 end


### PR DESCRIPTION
#### What?

Validação para hourly_rate em Self Employed Account e aplicando o `maskMoney` para uma nova aba de conta.

#### Why

Quando há o clique para adicionar uma nova conta, o plugin do maskMoney não é aplicado ao `input` do `hourly_rate`. Sendo assim, atualmente o usuário consegue cadastrar uma nova conta sendo `nil` ou vazia.
Neste _PR_ inclui:

- Adição de uma validação do formato `Big Decimal` para `hourly_rate`.
- Adição da máscara `maskMoney` para uma nova aba.
- Casting `to_i` para `hourly_rate` em [`account_presenter#total_earned`](https://github.com/thiago-sydow/controle-de-ponto/pull/150/files#diff-7786ea741c7cf029a73681c13a287502R34) para fixar o erro para usuários que tenham um campo `nil` salvo no banco - isto inclui a minha conta (=

#### Refs(#147 #148 #149)

/cc @thiago-sydow 