### PR TITLE
Add time records validations for only "work_day" day records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 #Ignore ruby-gemset file
 .ruby-gemset
 
+#Ignore ruby-version file
+.ruby-version
+
 # Ignore all logfiles and tempfiles.
 /log/*
 !/log/.keep

--- a/app/models/day_record.rb
+++ b/app/models/day_record.rb
@@ -20,6 +20,7 @@ class DayRecord
 
   validates_presence_of :reference_date
   validates_uniqueness_of :reference_date, scope: :account_id
+  validates :time_records, presence: true, if: :only_work_day?
 
   validate :future_reference_date
 
@@ -108,4 +109,7 @@ class DayRecord
     errors.add(:reference_date, :future_date) if reference_date.future?
   end
 
+  def only_work_day?
+    work_day.yes? and missed_day.no? and medical_certificate.no?
+  end
 end

--- a/app/models/day_record.rb
+++ b/app/models/day_record.rb
@@ -110,6 +110,6 @@ class DayRecord
   end
 
   def only_work_day?
-    work_day.yes? and missed_day.no? and medical_certificate.no?
+    work_day.yes? && missed_day.no? && medical_certificate.no?
   end
 end

--- a/spec/models/day_record_spec.rb
+++ b/spec/models/day_record_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe DayRecord do
         should_not validate_presence_of(:time_records)
       end
     end
-
   end
 
   context 'ordering' do

--- a/spec/models/day_record_spec.rb
+++ b/spec/models/day_record_spec.rb
@@ -13,14 +13,18 @@ RSpec.describe DayRecord do
 
     context 'when it is only work day' do
       it 'validates the presence of records' do
-        allow_any_instance_of(described_class).to receive(:only_work_day?) { true }
+        allow_any_instance_of(described_class).to receive(:only_work_day?) {
+          true
+        }
         should validate_presence_of(:time_records)
       end
     end
 
     context 'when it is not work day' do
       it 'does not validate the presence of records' do
-        allow_any_instance_of(described_class).to receive(:only_work_day?) { false }
+        allow_any_instance_of(described_class).to receive(:only_work_day?) {
+          false
+        }
         should_not validate_presence_of(:time_records)
       end
     end

--- a/spec/models/day_record_spec.rb
+++ b/spec/models/day_record_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe DayRecord do
   context 'validations' do
     it { is_expected.to validate_presence_of :reference_date }
     it { is_expected.to validate_uniqueness_of(:reference_date).scoped_to :account_id }
+
+    context 'when it is only work day' do
+      it 'validates the presence of records' do
+        allow_any_instance_of(described_class).to receive(:only_work_day?) { true }
+        should validate_presence_of(:time_records)
+      end
+    end
+
+    context 'when it is not work day' do
+      it 'does not validate the presence of records' do
+        allow_any_instance_of(described_class).to receive(:only_work_day?) { false }
+        should_not validate_presence_of(:time_records)
+      end
+    end
+
   end
 
   context 'ordering' do


### PR DESCRIPTION
@thiago-sydow @duduribeiro Para o issue #157, adicionei a validação no model `DayRecord`. Mas ainda é necessário acertar os testes. Pelo que vi, existem muitos testes que não dependem da existência de `time_records`. Essa implementação pode levar alguns dias.
