### PR TITLE
  Closes the time popover when switching fields using the tab key

### DIFF
--- a/app/assets/javascripts/backend-common.js
+++ b/app/assets/javascripts/backend-common.js
@@ -12,7 +12,7 @@ var closeTimePickerOnTabPress = function() {
       $(this).timepicker('hideWidget');
     }
   });
-}
+};
 
 $(function(){
 

--- a/app/assets/javascripts/backend-common.js
+++ b/app/assets/javascripts/backend-common.js
@@ -6,6 +6,14 @@ var updateTimeLabels = function() {
   });
 };
 
+var closeTimePickerOnTabPress = function() {
+  $('.timepicker').unbind('keydown').on('keydown', function(e) {
+    if(e.keyCode == 9) {
+      $(this).timepicker('hideWidget');
+    }
+  });
+}
+
 $(function(){
 
   $.fn.twitter_bootstrap_confirmbox.defaults = {
@@ -36,6 +44,7 @@ $(function(){
   })
   .on('cocoon:after-insert', function(e, insertedItem) {
     $(insertedItem).find('.timepicker').timepicker({showMeridian: false, minuteStep: 1});
+    closeTimePickerOnTabPress();
   })
   .on('cocoon:after-remove', function(e, insertedItem) {
     updateTimeLabels();
@@ -58,4 +67,5 @@ $(function(){
 	});
 
   updateTimeLabels();
+  closeTimePickerOnTabPress();
 });


### PR DESCRIPTION
@thiago-sydow  Criei a função closeTimePickerOnTabPress, que resolve a issue #156 . O popover é fechado caso o usuário esteja com o focus no campo e pressiona a tecla Tab.