### PR TITLE
Correção do saldo de horas

### DIFF
--- a/app/models/closure.rb
+++ b/app/models/closure.rb
@@ -10,7 +10,7 @@ class Closure
 
   validates_uniqueness_of :start_date, :end_date, scope: :account_id
 
-  default_scope -> { desc(:start_date) }
+  default_scope -> { desc(:end_date) }
 
   def balance
     account.day_records.where(reference_date: start_date..end_date).

--- a/app/presenters/account_presenter.rb
+++ b/app/presenters/account_presenter.rb
@@ -44,7 +44,7 @@ class AccountPresenter < Burgundy::Item
 
   def days_since_closure
     @days ||= if closures.exists?
-                day_records.where(:reference_date.gt => closures.last.end_date)
+                day_records.where(:reference_date.gt => closures.first.end_date)
               else
                 day_records
               end


### PR DESCRIPTION
Corrigindo bug #153.

Quando existira mais de um fechamento, o saldo de horas não exibia o valor correto, ignorando o último fechamento.

Closes #153 