### PR TITLE
Colunas de entrada/saida para o periodo

### DIFF
--- a/app/controllers/day_records_controller.rb
+++ b/app/controllers/day_records_controller.rb
@@ -8,7 +8,7 @@ class DayRecordsController < GenericCrudController
     all_records = current_account.day_records.includes(:time_records).date_range(@from, @to)
     @day_records = all_records.page params[:page]
     @balance_period = all_records.inject(TimeBalance.new) { |sum_balance, day| sum_balance.sum(day.balance) }
-    @max_time_records = DayRecord.max_time_count_for_account(current_account)
+    @max_time_records = TimeRecord.max_time_count(@day_records)
   end
 
   def new

--- a/app/models/day_record.rb
+++ b/app/models/day_record.rb
@@ -29,14 +29,6 @@ class DayRecord < ActiveRecord::Base
 
   after_destroy :touch_account
 
-  def self.max_time_count_for_account(account)
-    where(account: account)
-    .joins(:time_records)
-    .group(:id)
-    .select('day_records.*, count(time_records.id) as time_count')
-    .map { |day| day.time_count }.max || 0
-  end
-
   def total_worked
     @total_worked ||= calculate_total_worked_hours
   end

--- a/app/models/day_record/base_export.rb
+++ b/app/models/day_record/base_export.rb
@@ -25,7 +25,7 @@ class DayRecord::BaseExport
   def entrance_exits
     headers = []
 
-    DayRecord.max_time_count_for_account(@account).times do |index|
+    TimeRecord.max_time_count(@data).times do |index|
       headers << h.get_time_label_from_number(index)
     end
 

--- a/app/models/time_record.rb
+++ b/app/models/time_record.rb
@@ -7,6 +7,15 @@ class TimeRecord < ActiveRecord::Base
 
   after_initialize :set_default_values
 
+  def self.max_time_count(days_scope)
+    TimeRecord
+    .unscope(:order)
+    .where(day_record_id: days_scope.select(:id))
+    .group(:day_record_id)
+    .pluck("count(id) as time_count")
+    .max || 0
+  end
+
   private
 
   def set_default_values

--- a/spec/models/day_record_spec.rb
+++ b/spec/models/day_record_spec.rb
@@ -24,36 +24,6 @@ RSpec.describe DayRecord do
     it { expect(account.day_records).to eq [day_3, day_2, day_1] }
   end
 
-  describe '#max_time_count_for_account' do
-    let!(:account)   { create(:account) }
-    let!(:account_1) { create(:account) }
-    let!(:account_2) { create(:account) }
-    let!(:day_1)  { create(:day_record, account: account_1) }
-    let!(:day_2)  { create(:day_record, reference_date: 3.days.ago, account: account_2) }
-    let!(:time_1) { create(:time_record, time: 3.hours.ago, day_record: day_1) }
-    let!(:time_2) { create(:time_record, time: 2.hours.ago, day_record: day_2) }
-    let!(:time_3) { create(:time_record, time: 1.hours.ago, day_record: day_2) }
-
-    context 'when no day records exists' do
-      it { expect(DayRecord.max_time_count_for_account(account)).to eq 0 }
-    end
-
-    context 'when day record exist but no time records' do
-      let!(:day)  { create(:day_record, account: account) }
-
-      it { expect(DayRecord.max_time_count_for_account(account)).to eq 0 }
-    end
-
-    context 'when time records exists' do
-      it { expect(DayRecord.max_time_count_for_account(account_1)).to eq 1 }
-    end
-
-    context 'when multiple accounts have time records' do
-      it { expect(DayRecord.max_time_count_for_account(account_1)).to eq 1 }
-      it { expect(DayRecord.max_time_count_for_account(account_2)).to eq 2 }
-    end
-  end
-
   describe 'after_save' do
     let(:acc) { create(:account) }
     let!(:day)  { create(:day_record, account: acc, reference_date: 10.days.ago) }

--- a/spec/models/time_record_spec.rb
+++ b/spec/models/time_record_spec.rb
@@ -15,4 +15,34 @@ RSpec.describe TimeRecord do
 
     it { expect(day.reload.time_records).to eq [time_1, time_2, time_3] }
   end
+
+  describe '#max_time_count' do
+    let!(:account)   { create(:account) }
+    let!(:account_1) { create(:account) }
+    let!(:account_2) { create(:account) }
+    let!(:day_1)  { create(:day_record, account: account_1) }
+    let!(:day_2)  { create(:day_record, reference_date: 3.days.ago, account: account_2) }
+    let!(:time_1) { create(:time_record, time: 3.hours.ago, day_record: day_1) }
+    let!(:time_2) { create(:time_record, time: 2.hours.ago, day_record: day_2) }
+    let!(:time_3) { create(:time_record, time: 1.hours.ago, day_record: day_2) }
+
+    context 'when no day records exists' do
+      it { expect(TimeRecord.max_time_count(account.day_records)).to eq 0 }
+    end
+
+    context 'when day record exist but no time records' do
+      let!(:day)  { create(:day_record, account: account) }
+
+      it { expect(TimeRecord.max_time_count(account.day_records)).to eq 0 }
+    end
+
+    context 'when time records exists' do
+      it { expect(TimeRecord.max_time_count(account_1.day_records)).to eq 1 }
+    end
+
+    context 'when multiple accounts have time records' do
+      it { expect(TimeRecord.max_time_count(account_1.day_records)).to eq 1 }
+      it { expect(TimeRecord.max_time_count(account_2.day_records)).to eq 2 }
+    end
+  end
 end


### PR DESCRIPTION
Considerar o periodo selecionado em vez de todos os registros da conta.